### PR TITLE
setup-environment-internal: allow build location to be out-of-tree

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -1,7 +1,9 @@
 # LAYER_CONF_VERSION is increased each time build/conf/bblayers.conf
 # changes incompatibly
+include oeroot.conf
+
 LCONF_VERSION = "7"
-OEROOT := "${@os.path.abspath(os.path.dirname(d.getVar('FILE', True)))}/../.."
+OEROOT := "${@d.getVar("OEROOT")}"
 
 BBPATH = "${TOPDIR}"
 

--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -147,7 +147,9 @@ BUILDDIR=build-$DISTRO
 if [ $# -eq 1 ]; then
     BUILDDIR=$1
 fi
+if [[ ! "${BUILDDIR}" = /* ]]; then
 BUILDDIR=$OEROOT/$BUILDDIR
+fi
 
 # Clean up PATH, because if it includes tokens to current directories somehow,
 # wrong binaries can be used instead of the expected ones during task execution
@@ -250,6 +252,9 @@ SDKMACHINE ?= "${SDKMACHINE}"
 # Extra options that can be changed by the user
 INHERIT += "rm_work"
 EOF
+cat > conf/oeroot.conf <<EOF
+OEROOT ?= "${OEROOT}"
+EOF
 if [ ! -e conf/site.conf ]; then
     cat > conf/site.conf <<_EOF
 
@@ -278,7 +283,7 @@ fi
 # If the env variable EULA_$MACHINE is set it is used by default,
 # without prompting the user.
 # FIXME: there is a potential issue if the same $MACHINE is set in more than one layer.. but we should assert that earlier
-EULA=$(find ../layers -path "*/conf/eula/$MACHINE" -print | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro || true)
+EULA=$(find ${OEROOT}/layers -path "*/conf/eula/$MACHINE" -print | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro || true)
 
 if [ -n "$EULA" ]; then
 


### PR DESCRIPTION
Currently, the build output is always placed under the main repo tree.
This may be undesirable on some systems which want to make use of an
extra storage drive or ramfs for building packages.

Let's add the necessary logic to handle an out-of-tree build location:
- setup-environment-internal: pass the OEROOT value into an includable
  conf file, if the BUILDDIR is absolute to prepend the OEROOT location
  and don't assume a path location of "../" when scanning for eula
  files from the BUILDDIR
- bblayers.conf: use the OEROOT conf value and remove the relative
  build/conf path assumption (../..)

Example: MACHINE=hikey DISTRO=rpb . setup-environment /out/build-rpb

Change-Id: I141229a7a589c50aa12970b3ea5edcb5a3d99827
Signed-off-by: Michael Scott <michael.scott@linaro.org>